### PR TITLE
fix(action): use source repository name in commit message

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,9 +49,12 @@ runs:
         repository=${{ inputs.repository }}
         release_tag=${{ inputs.release_tag }}
 
+        # the repository running this action
+        source_repository=${{ github.event.repository.name }}
+
         if [ -z "${{ inputs.zipfile }}" ]; then
           # repository name in lowercase
-          repository_name=$(echo ${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]')
+          repository_name=$(echo ${source_repository} | tr '[:upper:]' '[:lower:]')
           zipfile_name=${repository_name}.zip
           zipfile_path=${{ github.workspace }}/${repository_name}.zip
         else
@@ -69,6 +72,8 @@ runs:
         echo "gh_pages_url=${gh_pages_url}" >> $GITHUB_OUTPUT
         echo "repository=${repository}" >> $GITHUB_OUTPUT
         echo "release_tag=${release_tag}" >> $GITHUB_OUTPUT
+
+        echo "source_repository=${source_repository}" >> $GITHUB_OUTPUT
 
         echo "plugin_url=${plugin_url}" >> $GITHUB_OUTPUT
         echo "zipfile_name=${zipfile_name}" >> $GITHUB_OUTPUT
@@ -124,5 +129,5 @@ runs:
         directory: ${{ steps.inputs.outputs.branch }}
         branch: ${{ steps.inputs.outputs.branch }}
         force: false
-        message: "Bump ${{ steps.inputs.outputs.repository }} to ${{ steps.inputs.outputs.release_tag }}"
+        message: "Bump ${{ steps.inputs.outputs.source_repository }} to ${{ steps.inputs.outputs.release_tag }}"
         repository: ${{ steps.inputs.outputs.repository }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
The repository name in the commit message is the name of the repo hosting the gh-pages branch. We actually want this to be the name of the repo running the action.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
